### PR TITLE
Add missing setFormat signature from latest P3R version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Jetbrains IDE (Rider)
+**/.idea/*

--- a/Ryo.Reloaded/CRI/CriAtomEx/CriAtomEx.cs
+++ b/Ryo.Reloaded/CRI/CriAtomEx/CriAtomEx.cs
@@ -146,7 +146,11 @@ internal unsafe class CriAtomEx : ICriAtomEx
                 lock (setFormatLock)
                 {
                     setFormatSignaturesScanned++;
-                    this.setFormat = hooks.CreateWrapper<criAtomExPlayer_SetFormat>(result, out _);
+                    if (this.setFormat == null)
+                    {
+                        scans.Broadcast<criAtomExPlayer_SetFormat>(result);
+                    }
+                    this.setFormat ??= hooks.CreateWrapper<criAtomExPlayer_SetFormat>(result, out _);
                 }
             }, () =>
             {

--- a/Ryo.Reloaded/CRI/CriAtomEx/CriAtomEx.cs
+++ b/Ryo.Reloaded/CRI/CriAtomEx/CriAtomEx.cs
@@ -46,7 +46,9 @@ internal unsafe class CriAtomEx : ICriAtomEx
     private readonly WrapperContainer<criAtomExCategory_GetVolume> getCategoryVolume;
     private readonly WrapperContainer<criAtomExCategory_GetVolumeById> getVolumeById;
     private readonly WrapperContainer<criAtomExCategory_SetVolume> setVolumeByIndex;
-    private criAtomExPlayer_SetFormat?[] setFormat;
+    private criAtomExPlayer_SetFormat? setFormat;
+    private readonly object setFormatLock = new();
+    private int setFormatSignaturesScanned;
     private readonly WrapperContainer<criAtomExPlayer_SetSamplingRate> setSamplingRate;
     private readonly WrapperContainer<criAtomExPlayer_SetNumChannels> setNumChannels;
     private readonly WrapperContainer<criAtomExPlayer_SetVolume> setVolume;
@@ -137,16 +139,38 @@ internal unsafe class CriAtomEx : ICriAtomEx
         scans.AddScan<criAtomExPlayer_GetNumPlayedSamples>(this.patterns.criAtomExPlayer_GetNumPlayedSamples);
         this.getNumPlayedSamples = scans.CreateWrapper<criAtomExPlayer_GetNumPlayedSamples>(Mod.NAME);
         
-        this.setFormat = GC.AllocateArray<criAtomExPlayer_SetFormat>(this.patterns.criAtomExPlayer_SetFormat.Length);
         foreach (var (Index, Candidate) in this.patterns.criAtomExPlayer_SetFormat.Select((x, i) => (i, x)))
         {
+            Project.Scans.AddScanHook($"criAtomExPlayer_SetFormat[{Index}]", Candidate, (result, hooks) =>
+            {
+                lock (setFormatLock)
+                {
+                    setFormatSignaturesScanned++;
+                    this.setFormat = hooks.CreateWrapper<criAtomExPlayer_SetFormat>(result, out _);
+                }
+            }, () =>
+            {
+                lock (setFormatLock)
+                {
+                    setFormatSignaturesScanned++;
+                    if (setFormatSignaturesScanned == this.patterns.criAtomExPlayer_SetFormat.Length)
+                    {
+                        Log.Error($"Failed to find a pattern for criAtomExPlayer_SetFormat.");
+                    }
+                    else
+                    {
+                        Log.Debug($"No matching pattern for criAtomExPlayer_SetFormat[{Index}].");
+                    }
+                }    
+            });
+            /*
             var ListenerId = $"criAtomExPlayer_SetFormat_{Index}";
             scans.AddScan(ListenerId, Candidate);
             scans.CreateListener(ListenerId, x =>
             {
                 this.setFormat[Index] = this.reloadedHooks.CreateWrapper<criAtomExPlayer_SetFormat>(x, out _);
             });
-            
+            */
         }
 
         scans.AddScan<criAtomExPlayer_SetSamplingRate>(this.patterns.criAtomExPlayer_SetSamplingRate);
@@ -225,10 +249,7 @@ internal unsafe class CriAtomEx : ICriAtomEx
 
     public void Player_SetAisacControlByName(nint playerHn, byte* controlName, float controlValue)  => this.setAisacControlByName.Wrapper(playerHn, controlName, controlValue);
 
-    public void Player_SetCueId(nint playerHn, nint acbHn, int cueId)
-    {
-        // this.setCueId_Normal
-    }
+    public void Player_SetCueId(nint playerHn, nint acbHn, int cueId) => this.setCueId.Wrapper(playerHn, acbHn, cueId);
 
     public void Player_SetCueName(nint playerHn, nint acbHn, byte* cueName)  => this.setCueName.Wrapper(playerHn, acbHn, cueName);
 
@@ -242,18 +263,7 @@ internal unsafe class CriAtomEx : ICriAtomEx
 
     public void Player_SetFile(nint playerHn, nint criBinderHn, byte* path) => this.setFile.Wrapper(playerHn, criBinderHn, path);
 
-    public void Player_SetFormat(nint playerHn, CriAtomFormat format)
-    {
-        foreach (var Candidate in this.setFormat)
-        {
-            if (Candidate != null)
-            {
-                Candidate(playerHn, format);
-                return;
-            }
-        }
-        Log.Error("No valid function available for Player_SetFormat!");
-    }
+    public void Player_SetFormat(nint playerHn, CriAtomFormat format) => this.setFormat!(playerHn, format);
 
     public void Player_SetNumChannels(nint playerHn, int numChannels) => this.setNumChannels.Wrapper(playerHn, numChannels);
 

--- a/Ryo.Reloaded/CRI/CriAtomEx/CriAtomEx.cs
+++ b/Ryo.Reloaded/CRI/CriAtomEx/CriAtomEx.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using Reloaded.Hooks.ReloadedII.Interfaces;
 using Ryo.Interfaces;
 using Ryo.Definitions.Structs;
 using Ryo.Definitions.Classes;
@@ -12,6 +13,7 @@ internal unsafe class CriAtomEx : ICriAtomEx
 {
     private readonly string game;
     private readonly CriAtomExPatterns patterns;
+    private readonly IReloadedHooks reloadedHooks;
 
     private readonly Dictionary<int, CriAtomExPlayerConfigTag> playerConfigs = new();
     private readonly List<PlayerConfig> players = new();
@@ -25,6 +27,7 @@ internal unsafe class CriAtomEx : ICriAtomEx
     private readonly HookContainer<criAtomAwb_LoadToc> loadToc;
 
     // Wrappers.
+    
     private readonly WrapperContainer<criAtomExPlayer_SetCueId> setCueId;
     private readonly WrapperContainer<criAtomExPlayer_SetCueName> setCueName;
     private readonly WrapperContainer<criAtomExPlayer_SetFile> setFile;
@@ -43,7 +46,7 @@ internal unsafe class CriAtomEx : ICriAtomEx
     private readonly WrapperContainer<criAtomExCategory_GetVolume> getCategoryVolume;
     private readonly WrapperContainer<criAtomExCategory_GetVolumeById> getVolumeById;
     private readonly WrapperContainer<criAtomExCategory_SetVolume> setVolumeByIndex;
-    private readonly WrapperContainer<criAtomExPlayer_SetFormat> setFormat;
+    private criAtomExPlayer_SetFormat?[] setFormat;
     private readonly WrapperContainer<criAtomExPlayer_SetSamplingRate> setSamplingRate;
     private readonly WrapperContainer<criAtomExPlayer_SetNumChannels> setNumChannels;
     private readonly WrapperContainer<criAtomExPlayer_SetVolume> setVolume;
@@ -57,10 +60,12 @@ internal unsafe class CriAtomEx : ICriAtomEx
     private readonly WrapperContainer<criAtomExPlayer_SetAisacControlByName> setAisacControlByName;
     private readonly WrapperContainer<criAtomExAcf_GetCategoryInfoByIndex> acfGetCategoryInfoById;
 
-    public CriAtomEx(string game, ISharedScans scans)
+    public CriAtomEx(string game, ISharedScans scans, IReloadedHooks reloadedHooks)
     {
         this.game = game;
         this.patterns = CriAtomExPatterns.GetGamePatterns(game);
+        this.reloadedHooks = reloadedHooks;
+        
 
         scans.AddScan<criAtomExPlayer_SetCueId>(this.patterns.criAtomExPlayer_SetCueId);
         this.setCueId = scans.CreateWrapper<criAtomExPlayer_SetCueId>(Mod.NAME);
@@ -131,9 +136,18 @@ internal unsafe class CriAtomEx : ICriAtomEx
 
         scans.AddScan<criAtomExPlayer_GetNumPlayedSamples>(this.patterns.criAtomExPlayer_GetNumPlayedSamples);
         this.getNumPlayedSamples = scans.CreateWrapper<criAtomExPlayer_GetNumPlayedSamples>(Mod.NAME);
-
-        scans.AddScan<criAtomExPlayer_SetFormat>(this.patterns.criAtomExPlayer_SetFormat);
-        this.setFormat = scans.CreateWrapper<criAtomExPlayer_SetFormat>(Mod.NAME);
+        
+        this.setFormat = GC.AllocateArray<criAtomExPlayer_SetFormat>(this.patterns.criAtomExPlayer_SetFormat.Length);
+        foreach (var (Index, Candidate) in this.patterns.criAtomExPlayer_SetFormat.Select((x, i) => (i, x)))
+        {
+            var ListenerId = $"criAtomExPlayer_SetFormat_{Index}";
+            scans.AddScan(ListenerId, Candidate);
+            scans.CreateListener(ListenerId, x =>
+            {
+                this.setFormat[Index] = this.reloadedHooks.CreateWrapper<criAtomExPlayer_SetFormat>(x, out _);
+            });
+            
+        }
 
         scans.AddScan<criAtomExPlayer_SetSamplingRate>(this.patterns.criAtomExPlayer_SetSamplingRate);
         this.setSamplingRate = scans.CreateWrapper<criAtomExPlayer_SetSamplingRate>(Mod.NAME);
@@ -211,7 +225,10 @@ internal unsafe class CriAtomEx : ICriAtomEx
 
     public void Player_SetAisacControlByName(nint playerHn, byte* controlName, float controlValue)  => this.setAisacControlByName.Wrapper(playerHn, controlName, controlValue);
 
-    public void Player_SetCueId(nint playerHn, nint acbHn, int cueId)  => this.setCueId.Wrapper(playerHn, acbHn, cueId);
+    public void Player_SetCueId(nint playerHn, nint acbHn, int cueId)
+    {
+        // this.setCueId_Normal
+    }
 
     public void Player_SetCueName(nint playerHn, nint acbHn, byte* cueName)  => this.setCueName.Wrapper(playerHn, acbHn, cueName);
 
@@ -225,7 +242,18 @@ internal unsafe class CriAtomEx : ICriAtomEx
 
     public void Player_SetFile(nint playerHn, nint criBinderHn, byte* path) => this.setFile.Wrapper(playerHn, criBinderHn, path);
 
-    public void Player_SetFormat(nint playerHn, CriAtomFormat format) => this.setFormat.Wrapper(playerHn, format);
+    public void Player_SetFormat(nint playerHn, CriAtomFormat format)
+    {
+        foreach (var Candidate in this.setFormat)
+        {
+            if (Candidate != null)
+            {
+                Candidate(playerHn, format);
+                return;
+            }
+        }
+        Log.Error("No valid function available for Player_SetFormat!");
+    }
 
     public void Player_SetNumChannels(nint playerHn, int numChannels) => this.setNumChannels.Wrapper(playerHn, numChannels);
 

--- a/Ryo.Reloaded/CRI/CriAtomEx/CriAtomExPatterns.cs
+++ b/Ryo.Reloaded/CRI/CriAtomEx/CriAtomExPatterns.cs
@@ -9,7 +9,7 @@ internal class CriAtomExPatterns
     public string? criAtomExPlayer_SetCueId { get; init; }
     public string? criAtomExPlayer_Start { get; init; }
     public string? criAtomExPlayer_SetFile { get; init; }
-    public string? criAtomExPlayer_SetFormat { get; init; }
+    public string[] criAtomExPlayer_SetFormat { get; init; } = [];
     public string? criAtomExPlayer_SetSamplingRate { get; init; }
     public string? criAtomExPlayer_SetNumChannels { get; init; }
     public string? criAtomExCategory_GetVolumeById { get; init; }
@@ -53,7 +53,10 @@ internal class CriAtomExPatterns
                 criAtomExPlayer_Create = "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 40 45 33 ED 41 8B F8",
                 criAtomExPlayer_Start = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 44 8D 41 ?? 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 83 C8 FF",
                 criAtomExPlayer_SetData = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 44 89 C6",
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15",
+                criAtomExPlayer_SetFormat = [
+                    "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15", // Standard Signature
+                    "48 89 5C 24 ?? 57 48 83 EC 20 48 89 CF 48 85 C9" // Steam 1.0.11
+                ], 
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 89 D7 48 89 CB 48 85 C9 74 ?? 8D 42",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 89 D7 48 89 CB 48 85 C9 74 ?? 85 D2",
                 criAtomExPlayer_SetCategoryById = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 50 48 8B F9 8B F2",
@@ -77,7 +80,7 @@ internal class CriAtomExPatterns
             {
                 criAtomExPlayer_Create = "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 40 45 33 E4",
                 criAtomExPlayer_Start = "48 89 5C 24 ?? 57 48 83 EC 20 48 89 CF 48 85 C9 75 ?? 44 8D 41",
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15",
+                criAtomExPlayer_SetFormat = ["48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15"],
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 8D 42",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 85 D2",
                 criAtomExPlayer_SetCategoryById = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 50 48 8B F9 8B F2",
@@ -102,7 +105,7 @@ internal class CriAtomExPatterns
                 criAtomExPlayer_Create = "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 40 45 33 E4",
                 //criAtomExPlayer_Start = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 44 8D 41 ?? 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 83 C8 FF",
                 criAtomExPlayer_SetData = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 41 8B F0 48 8B EA",
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15",
+                criAtomExPlayer_SetFormat = ["48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15"],
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 8D 42",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 85 D2",
 
@@ -123,7 +126,7 @@ internal class CriAtomExPatterns
                 criAtomExPlayer_Create = "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 40 45 33 ED 41 8B F8",
                 criAtomExPlayer_Start = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 44 8D 41 ?? 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 83 C8 FF",
                 criAtomExPlayer_SetData = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 44 89 C6",
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15",
+                criAtomExPlayer_SetFormat = ["48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15"],
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 89 D7 48 89 CB 48 85 C9 74 ?? 8D 42",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 89 D7 48 89 CB 48 85 C9 74 ?? 85 D2",
                 criAtomExPlayer_SetCueName = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 49 8B F8 48 8B EA 48 8B D9 48 85 C9",
@@ -143,7 +146,7 @@ internal class CriAtomExPatterns
             {
                 criAtomExPlayer_Create = "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 40 45 33 ED",
                 criAtomExPlayer_Start = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 44 8D 41 ?? 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 83 C8 FF EB ?? E8 ?? ?? ?? ?? 33 D2",
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15",
+                criAtomExPlayer_SetFormat = ["48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15"],
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 8D 42",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 85 D2",
                 criAtomExPlayer_SetCategoryById = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 50 48 8B F9 8B F2",
@@ -167,7 +170,7 @@ internal class CriAtomExPatterns
             {
                 criAtomExPlayer_Create = "40 55 53 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ?? 48 81 EC C8 00 00 00 45 8B F8",
                 criAtomExPlayer_Start = "48 89 E0 48 89 58 ?? 48 89 68 ?? 48 89 70 ?? 48 89 78 ?? 41 56 48 83 EC 60",
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15",
+                criAtomExPlayer_SetFormat = ["48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15"],
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 8D 42",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 85 D2",
                 criAtomExPlayer_SetCategoryById = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 50 48 8B F9 8B F2",
@@ -202,7 +205,7 @@ internal class CriAtomExPatterns
             {
                 criAtomExPlayer_Create = "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 40 45 33 E4",
                 criAtomExPlayer_Start = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 44 8D 41 ?? 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 83 C8 FF EB ?? E8 ?? ?? ?? ?? 33 D2",
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15",
+                criAtomExPlayer_SetFormat = ["48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15"],
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 8D 42",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 85 D2",
 
@@ -226,7 +229,7 @@ internal class CriAtomExPatterns
             {
                 criAtomExPlayer_Create = "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 40 45 33 E4",
                 criAtomExPlayer_Start = "48 89 5C 24 ?? 57 48 83 EC 20 48 89 CF 48 85 C9 75 ?? 8B 15 ?? ?? ?? ??", // denuvo moment
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 89 CF 48 85 C9 75 ?? 48 8D 15 ?? ?? ?? ??",
+                criAtomExPlayer_SetFormat = ["48 89 5C 24 ?? 57 48 83 EC 20 48 89 CF 48 85 C9 75 ?? 48 8D 15 ?? ?? ?? ??"],
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 89 D7 48 89 CB 48 85 C9 74 ?? 8D 42 ??",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 89 D7 48 89 CB 48 85 C9 74 ?? 85 D2",
                 criAtomExPlayer_SetFile = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 49 8B F0 48 8B EA 48 8B F9 48 85 C9",
@@ -246,7 +249,7 @@ internal class CriAtomExPatterns
             {
                 criAtomExPlayer_Create = "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 40 45 33 E4",
                 criAtomExPlayer_Start = "48 89 5C 24 ?? 57 48 83 EC 20 48 89 CF 48 85 C9 75 ?? 44 8D 41 ?? 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 83 C8 FF EB ?? E8 ?? ?? ?? ?? 31 D2",
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 89 CF 48 85 C9 75 ?? 48 8D 15 ?? ?? ?? ??",
+                criAtomExPlayer_SetFormat = ["48 89 5C 24 ?? 57 48 83 EC 20 48 89 CF 48 85 C9 75 ?? 48 8D 15 ?? ?? ?? ??"],
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 89 D7 48 89 CB 48 85 C9 74 ?? 8D 42 ??",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 89 D7 48 89 CB 48 85 C9 74 ?? 85 D2",
                 criAtomExPlayer_SetFile = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 49 8B F0 48 8B EA 48 8B F9 48 85 C9",
@@ -265,7 +268,7 @@ internal class CriAtomExPatterns
             {
                 criAtomExPlayer_Create = "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 40 45 33 E4",
                 criAtomExPlayer_Start = "48 89 5C 24 ?? 57 48 83 EC 20 48 89 CF 48 85 C9 75 ?? 44 8D 41 ?? 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 83 C8 FF EB ?? E8 ?? ?? ?? ?? 31 D2",
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15 ?? ?? ?? ??",
+                criAtomExPlayer_SetFormat = ["48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15 ?? ?? ?? ??"],
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 8D 42 ??",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 85 D2",
                 criAtomExPlayer_SetFile = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 49 8B F0 48 8B EA 48 8B F9 48 85 C9",
@@ -284,7 +287,7 @@ internal class CriAtomExPatterns
             {
                 criAtomExPlayer_Create = "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 40 45 33 ED",
                 criAtomExPlayer_Start = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 44 8D 41 ?? 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 83 C8 FF EB ?? E8 ?? ?? ?? ?? 33 D2",
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15 ?? ?? ?? ??",
+                criAtomExPlayer_SetFormat = ["48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15 ?? ?? ?? ??"],
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 8D 42 ??",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 85 D2",
                 criAtomExPlayer_SetFile = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 49 8B F0 48 8B EA 48 8B F9 48 85 C9",
@@ -304,7 +307,7 @@ internal class CriAtomExPatterns
                 criAtomExPlayer_Create = "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 40 45 33 E4 41 8B F8",
                 criAtomExPlayer_Start = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 44 8D 41 ?? 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 83 C8 FF",
                 criAtomExPlayer_SetData = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 41 8B F0 48 8B EA",
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15 ?? ?? ?? ??",
+                criAtomExPlayer_SetFormat = ["48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15 ?? ?? ?? ??"],
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 8D 42 ??",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 85 D2",
                 criAtomExPlayer_SetCueName = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 49 8B F8 48 8B EA 48 8B D9 48 85 C9",
@@ -326,7 +329,7 @@ internal class CriAtomExPatterns
                 criAtomExPlayer_Create = "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 40 45 33 E4",
                 criAtomExPlayer_Start = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 44 8D 41 ?? 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 83 C8 FF",
                 criAtomExPlayer_SetData = "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 41 8B F0 48 8B EA",
-                criAtomExPlayer_SetFormat = "48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15 ?? ?? ?? ?? 41 B8 FE FF FF FF",
+                criAtomExPlayer_SetFormat = ["48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 85 C9 75 ?? 48 8D 15 ?? ?? ?? ?? 41 B8 FE FF FF FF"],
                 criAtomExPlayer_SetNumChannels = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 8D 42 ??",
                 criAtomExPlayer_SetSamplingRate = "48 89 5C 24 ?? 57 48 83 EC 20 8B FA 48 8B D9 48 85 C9 74 ?? 85 D2",
                 criAtomExPlayer_SetCueName = "48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC 20 45 33 F6 49 8B F0 48 8B FA",

--- a/Ryo.Reloaded/Mod.cs
+++ b/Ryo.Reloaded/Mod.cs
@@ -14,6 +14,7 @@ using Ryo.Reloaded.Template;
 using SharedScans.Interfaces;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using Reloaded.Hooks.ReloadedII.Interfaces;
 using Ryo.Reloaded.CRI;
 using Ryo.Reloaded.CRI.CriWare;
 
@@ -24,6 +25,7 @@ public unsafe class Mod : ModBase, IExports
     public const string NAME = "Ryo";
 
     private readonly IModLoader modLoader;
+    private readonly IReloadedHooks reloadedHooks;
     private readonly ILogger log;
     private readonly IMod owner;
 
@@ -53,6 +55,7 @@ public unsafe class Mod : ModBase, IExports
         this.owner = context.Owner;
         this.config = context.Configuration;
         this.modConfig = context.ModConfig;
+        this.reloadedHooks = context.Hooks!;
 
 #if DEBUG
         Debugger.Launch();
@@ -65,8 +68,8 @@ public unsafe class Mod : ModBase, IExports
         Log.Debug($"Game: {game}");
 
         this.modLoader.GetController<ISharedScans>().TryGetTarget(out var scans);
-
-        this.criAtomEx = new(this.game, scans!);
+        
+        this.criAtomEx = new(this.game, scans!, this.reloadedHooks);
         this.modLoader.AddOrReplaceController<ICriAtomEx>(this.owner, this.criAtomEx);
 
         this.criAtomRegistry = new();

--- a/Ryo.Reloaded/ModConfig.json
+++ b/Ryo.Reloaded/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "Ryo.Reloaded",
   "ModName": "Ryo Framework",
   "ModAuthor": "RyoTune",
-  "ModVersion": "2.11.3",
+  "ModVersion": "2.11.4",
   "ModDescription": "Ryo Framework adds the ability to add or replace game audio and movies with zero file editing.",
   "ModDll": "Ryo.Reloaded.dll",
   "ModIcon": "Preview.png",


### PR DESCRIPTION
Fixes an issue in the latest Steam release of P3R where the signature for setFormat is not found due.

I've also added multiple signature support (setFormat only for now) which allows for multiple signature candidates for a given function. This should allow Ryo to continue working on older P3R versions.