### PR TITLE
SetFormat: Add Scans INI check

### DIFF
--- a/Ryo.Reloaded/CRI/CriAtomEx/CriAtomEx.cs
+++ b/Ryo.Reloaded/CRI/CriAtomEx/CriAtomEx.cs
@@ -5,6 +5,7 @@ using Ryo.Definitions.Structs;
 using Ryo.Definitions.Classes;
 using static Ryo.Definitions.Functions.CriAtomExFunctions;
 using Ryo.Definitions.Enums;
+using Ryo.Reloaded.Common;
 using SharedScans.Interfaces;
 
 namespace Ryo.Reloaded.CRI.CriAtomEx;
@@ -46,9 +47,7 @@ internal unsafe class CriAtomEx : ICriAtomEx
     private readonly WrapperContainer<criAtomExCategory_GetVolume> getCategoryVolume;
     private readonly WrapperContainer<criAtomExCategory_GetVolumeById> getVolumeById;
     private readonly WrapperContainer<criAtomExCategory_SetVolume> setVolumeByIndex;
-    private criAtomExPlayer_SetFormat? setFormat;
-    private readonly object setFormatLock = new();
-    private int setFormatSignaturesScanned;
+    private readonly MultiSignature<criAtomExPlayer_SetFormat> setFormat;
     private readonly WrapperContainer<criAtomExPlayer_SetSamplingRate> setSamplingRate;
     private readonly WrapperContainer<criAtomExPlayer_SetNumChannels> setNumChannels;
     private readonly WrapperContainer<criAtomExPlayer_SetVolume> setVolume;
@@ -138,44 +137,8 @@ internal unsafe class CriAtomEx : ICriAtomEx
 
         scans.AddScan<criAtomExPlayer_GetNumPlayedSamples>(this.patterns.criAtomExPlayer_GetNumPlayedSamples);
         this.getNumPlayedSamples = scans.CreateWrapper<criAtomExPlayer_GetNumPlayedSamples>(Mod.NAME);
-        
-        foreach (var (Index, Candidate) in this.patterns.criAtomExPlayer_SetFormat.Select((x, i) => (i, x)))
-        {
-            Project.Scans.AddScanHook($"criAtomExPlayer_SetFormat[{Index}]", Candidate, (result, hooks) =>
-            {
-                lock (setFormatLock)
-                {
-                    setFormatSignaturesScanned++;
-                    if (this.setFormat == null)
-                    {
-                        scans.Broadcast<criAtomExPlayer_SetFormat>(result);
-                    }
-                    this.setFormat ??= hooks.CreateWrapper<criAtomExPlayer_SetFormat>(result, out _);
-                }
-            }, () =>
-            {
-                lock (setFormatLock)
-                {
-                    setFormatSignaturesScanned++;
-                    if (setFormatSignaturesScanned == this.patterns.criAtomExPlayer_SetFormat.Length)
-                    {
-                        Log.Error($"Failed to find a pattern for criAtomExPlayer_SetFormat.");
-                    }
-                    else
-                    {
-                        Log.Debug($"No matching pattern for criAtomExPlayer_SetFormat[{Index}].");
-                    }
-                }    
-            });
-            /*
-            var ListenerId = $"criAtomExPlayer_SetFormat_{Index}";
-            scans.AddScan(ListenerId, Candidate);
-            scans.CreateListener(ListenerId, x =>
-            {
-                this.setFormat[Index] = this.reloadedHooks.CreateWrapper<criAtomExPlayer_SetFormat>(x, out _);
-            });
-            */
-        }
+
+        this.setFormat = new(scans, this.patterns.criAtomExPlayer_SetFormat);
 
         scans.AddScan<criAtomExPlayer_SetSamplingRate>(this.patterns.criAtomExPlayer_SetSamplingRate);
         this.setSamplingRate = scans.CreateWrapper<criAtomExPlayer_SetSamplingRate>(Mod.NAME);
@@ -267,7 +230,7 @@ internal unsafe class CriAtomEx : ICriAtomEx
 
     public void Player_SetFile(nint playerHn, nint criBinderHn, byte* path) => this.setFile.Wrapper(playerHn, criBinderHn, path);
 
-    public void Player_SetFormat(nint playerHn, CriAtomFormat format) => this.setFormat!(playerHn, format);
+    public void Player_SetFormat(nint playerHn, CriAtomFormat format) => this.setFormat.Function.Wrapper(playerHn, format);
 
     public void Player_SetNumChannels(nint playerHn, int numChannels) => this.setNumChannels.Wrapper(playerHn, numChannels);
 

--- a/Ryo.Reloaded/Common/MultiSignature.cs
+++ b/Ryo.Reloaded/Common/MultiSignature.cs
@@ -1,0 +1,56 @@
+﻿using SharedScans.Interfaces;
+
+namespace Ryo.Reloaded.Common;
+
+public class MultiSignature<TFunction>
+{
+    public readonly WrapperContainer<TFunction> Function;
+    // public TFunction? Wrapper;
+    private readonly object Lock = new();
+    private string[] Signatures;
+    private int ScansCompleted;
+
+    // Add support for multiple signature candidates to allow support for multiple game versions instead of *just* the
+    // latest version. The selected function will be the first candidate to successfully match their signature to
+    // some offset in the executable.
+    // Note that if you are using both hardcoded signatures and Scan INI, the mod may complain that it can't find a
+    // signature from the hardcoded list but does from Scan INI.
+    public MultiSignature(ISharedScans scans, string[] Signatures)
+    {
+        this.Signatures = Signatures;
+        // Check for a single pattern defined inside a Scan INI
+        scans.AddScan(typeof(TFunction).Name, null);
+        Function = scans.CreateWrapper<TFunction>(Mod.NAME);
+        
+        // Check for multiple signature candidates defined in code
+        foreach (var (Index, Candidate) in this.Signatures.Select((x, i) => (i, x)))
+        {
+            Project.Scans.AddScanHook($"{typeof(TFunction).Name}[{Index}]", Candidate, (result, hooks) =>
+            {
+                lock (Lock)
+                {
+                    ScansCompleted++;
+                    if (Function.Wrapper == null)
+                    {
+                        scans.Broadcast<TFunction>(result);
+                    }
+                    Function.Wrapper ??= hooks.CreateWrapper<TFunction>(result, out _);
+                }
+            }, () =>
+            {
+                lock (Lock)
+                {
+                    ScansCompleted++;
+                    if (Function.Wrapper == null && ScansCompleted == this.Signatures.Length)
+                    {
+                        Log.Error($"Failed to find a pattern for {typeof(TFunction).Name}.");
+                    }
+                    else
+                    {
+                        Log.Debug($"No matching pattern for {typeof(TFunction).Name}[{Index}].");
+                    }
+                }    
+            });
+        }
+    }
+}

--- a/Ryo.Reloaded/ModConfig.json
+++ b/Ryo.Reloaded/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "Ryo.Reloaded",
   "ModName": "Ryo Framework",
   "ModAuthor": "RyoTune",
-  "ModVersion": "2.11.4",
+  "ModVersion": "2.11.5",
   "ModDescription": "Ryo Framework adds the ability to add or replace game audio and movies with zero file editing.",
   "ModDll": "Ryo.Reloaded.dll",
   "ModIcon": "Preview.png",


### PR DESCRIPTION
Fixed an issue where Ryo was not listening for setFormat signature broadcasts from Scans INI (this caused Digimon Story Time Stranger to crash). Multiple signature functionality has also been formalized as the `MultiSignature` class.